### PR TITLE
Improved build process and configuration

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.bash text eol=lf

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ emerge-webrsync
 
 # Upgrade the compiler and the required libtool library
 emerge --oneshot --deep sys-devel/gcc
-emerge --oneshot --usepkg=n sys-devel/libtool
+emerge --ask --oneshot --usepkg=n dev-build/libtool
 
 # Update all packages with the newly built compiler
 # This will take a long time, ~1-5 hours
@@ -85,26 +85,19 @@ Sync via git which is fast, secure and up-to-date
 ```shell
 emerge --ask dev-vcs/git
 ```
-Make changes in portage config file under `/etc/portage/repos.conf/gentoo.conf` that holds the configuration for the main gentoo repository:
-
-Replace, 
-
+First disable the gentoo repository: 
 ```shell
-sync-type = rsync
-sync-uri = rsync://rsync.de.gentoo.org/gentoo-portage/
+eselect repository disable gentoo
 ```
-
-with
-
+Then enable the gentoo repository, using git as the sync type: 
 ```shell
-sync-type = git
-sync-uri = https://github.com/gentoo-mirror/gentoo.git
+eselect repository enable gentoo git
 ```
-
 Finally,
 ```shell
-rm -r /var/db/repos/gentoo # delete the old rsync-managed repository
-emerge --sync
+mv /var/db/repos/gentoo /var/db/repos/gentoo.old-rsync 
+emaint sync -r gentoo 
+rm -r /var/db/repos/gentoo.old-rsync 
 ```
 
 Subsequent syncs should be now faster.

--- a/build.sh
+++ b/build.sh
@@ -59,9 +59,9 @@ cat <<EOF > rootfs/etc/portage/make.conf
 # No GUI (-X -gtk), only english error messages (-nls)
 USE="-X -gtk -nls"
 
-# Enable python 3.7 and set 3.6 as default
-PYTHON_TARGETS="python3_6 python3_7"
-PYTHON_SINGLE_TARGET="python3_6"
+# Enable python 3.12 and set it as default
+PYTHON_TARGETS="python3_12"
+PYTHON_SINGLE_TARGET="python3_12"
 
 # Define targets for QEMU
 QEMU_SOFTMMU_TARGETS="aarch64 arm i386 riscv32 riscv64 x86_64"
@@ -77,12 +77,12 @@ FEATURES="-ipc-sandbox -pid-sandbox -mount-sandbox -network-sandbox"
 EMERGE_DEFAULT_OPTS="--ask --complete-graph"
 
 # Enable optimizations for the used CPU
-#COMMON_FLAGS="-march=haswell -O2 -pipe"
+#COMMON_FLAGS="-march=native -O2 -pipe"
 #CHOST="x86_64-pc-linux-gnu"
-#CFLAGS="${COMMON_FLAGS}"
-#CXXFLAGS="${COMMON_FLAGS}"
-#FCFLAGS="${COMMON_FLAGS}"
-#FFLAGS="${COMMON_FLAGS}"
+#CFLAGS="\${COMMON_FLAGS}"
+#CXXFLAGS="\${COMMON_FLAGS}"
+#FCFLAGS="\${COMMON_FLAGS}"
+#FFLAGS="\${COMMON_FLAGS}"
 #MAKEOPTS="-j5"
 
 # NOTE: This stage was built with the bindist Use flag enabled

--- a/build.sh
+++ b/build.sh
@@ -4,7 +4,7 @@ export PATH=/usr/.bin:$PATH
 
 # Env variables for the Gentoo image
 OS_VER="stable"
-ROOTFS_VER="20240218T170410Z"
+ROOTFS_VER="20240602T164858Z"
 ROOTFS_URL="https://gentoo.osuosl.org/releases/amd64/autobuilds/current-stage3-amd64-nomultilib-openrc/stage3-amd64-nomultilib-openrc-${ROOTFS_VER}.tar.xz"
 
 # Environment variables for Yuk7's wsldl


### PR DESCRIPTION
- Added `.gitattributes` so when you clone the project, you will have right-line endings for the bash files.
- Updated `PYTHON_TARGETS` and `PYTHON_SINGLE_TARGET` to `python3_12`. (As recommended [here](https://www.gentoo.org/support/news-items/2024-05-09-python3-12.html))
- Fixed a bug in `build.sh` with `${COMMON_FLAGS}` not being copied correctly. (Currently, it copied the value of the variable `COMMON_FLAGS`, which is of course not set, as we want the actual text of `${COMMON_FLAGS}` copied there.)
- Changed `-march` to `native` by default, which makes more sense.
- Fixed the wrong command for installing `libtool`.
- Replaced the manual way of configuring the ebuild repository with an automatic configuration using `eselect`.